### PR TITLE
Fix for NewHorizons/issues/3761, added config file check for acceptable

### DIFF
--- a/src/mod/gcewing/architecture/SawbenchTE.java
+++ b/src/mod/gcewing/architecture/SawbenchTE.java
@@ -6,6 +6,9 @@
 
 package gcewing.architecture;
 
+import java.util.List;
+import java.util.Arrays;
+
 import net.minecraft.block.*;
 import net.minecraft.entity.player.*;
 import net.minecraft.init.Blocks;
@@ -20,182 +23,194 @@ import static gcewing.architecture.Shape.*;
 
 public class SawbenchTE extends BaseTileInventory {
 
-	final public static int materialSlot = 0;
-	final public static int resultSlot = 1;
-	
-	final public static int[] materialSideSlots = {materialSlot};
-	final public static int[] resultSideSlots = {resultSlot};
+    final public static int materialSlot = 0;
+    final public static int resultSlot = 1;
+    
+    final public static int[] materialSideSlots = {materialSlot};
+    final public static int[] resultSideSlots = {resultSlot};
 
-	public static boolean allowAutomation = false;
-	
-	public static ShapePage[] pages = {
-		new ShapePage("Roofing",
-			RoofTile, RoofOuterCorner, RoofInnerCorner,
-			RoofRidge, RoofSmartRidge, RoofValley,
-			RoofSmartValley, RoofOverhang, RoofOverhangOuterCorner,
-			RoofOverhangInnerCorner, RoofOverhangGableLH, RoofOverhangGableRH,
-			RoofOverhangGableEndLH, RoofOverhangGableEndRH, RoofOverhangRidge,
-			RoofOverhangValley, BevelledOuterCorner, BevelledInnerCorner),
-		new ShapePage("Rounded",
-			Cylinder, CylinderHalf, CylinderQuarter, CylinderLargeQuarter, AnticylinderLargeQuarter,
-			Pillar, Post, Pole, SphereFull, SphereHalf,
-			SphereQuarter, SphereEighth, SphereEighthLarge, SphereEighthLargeRev),
-		new ShapePage("Classical",
-			PillarBase, Pillar, DoricCapital, DoricTriglyph, DoricTriglyphCorner, DoricMetope,
-			IonicCapital, CorinthianCapital, Architrave, ArchitraveCorner, CorniceLH, CorniceRH,
-			CorniceEndLH, CorniceEndRH, CorniceRidge, CorniceValley, CorniceBottom),
-		new ShapePage("Window",
-			WindowFrame, WindowCorner, WindowMullion),
-		new ShapePage("Arches",
-			ArchD1, ArchD2, ArchD3A, ArchD3B, ArchD3C, ArchD4A, ArchD4B, ArchD4C),
-		new ShapePage("Railings",
-			BalustradePlain, BalustradePlainOuterCorner, BalustradePlainInnerCorner,
-			BalustradePlainWithNewel, BalustradePlainEnd,
-			BanisterPlainTop, BanisterPlain, BanisterPlainBottom, BanisterPlainEnd, BanisterPlainInnerCorner,
-			BalustradeFancy, BalustradeFancyCorner, BalustradeFancyWithNewel, BalustradeFancyNewel,
-			BanisterFancyTop, BanisterFancy, BanisterFancyBottom, BanisterFancyEnd, BanisterFancyNewelTall),
-		new ShapePage("Other",
-			CladdingSheet, Slab, Stairs, StairsOuterCorner, StairsInnerCorner),
-	};
-	
-	public IInventory inventory = new InventoryBasic("Items", false, 2);
-	public int selectedPage = 0;
-	public int[] selectedSlots = new int[pages.length];
-	public boolean pendingMaterialUsage = false; // Material for the stack in the result slot
-	                                      // has not yet been removed from the material slot
-	                                      
-	public Shape getSelectedShape() {
-		if (selectedPage >= 0 && selectedPage < pages.length) {
-			int slot = selectedSlots[selectedPage];
-			if (slot >= 0 && slot < pages[selectedPage].size())
-				return pages[selectedPage].get(slot);
-		}
-		return null;
-	}
-	
-	@Override
-	protected IInventory getInventory() {
-		return inventory;
-	}
+    public static boolean allowAutomation = false;
+    
+    public static ShapePage[] pages = {
+        new ShapePage("Roofing",
+            RoofTile, RoofOuterCorner, RoofInnerCorner,
+            RoofRidge, RoofSmartRidge, RoofValley,
+            RoofSmartValley, RoofOverhang, RoofOverhangOuterCorner,
+            RoofOverhangInnerCorner, RoofOverhangGableLH, RoofOverhangGableRH,
+            RoofOverhangGableEndLH, RoofOverhangGableEndRH, RoofOverhangRidge,
+            RoofOverhangValley, BevelledOuterCorner, BevelledInnerCorner),
+        new ShapePage("Rounded",
+            Cylinder, CylinderHalf, CylinderQuarter, CylinderLargeQuarter, AnticylinderLargeQuarter,
+            Pillar, Post, Pole, SphereFull, SphereHalf,
+            SphereQuarter, SphereEighth, SphereEighthLarge, SphereEighthLargeRev),
+        new ShapePage("Classical",
+            PillarBase, Pillar, DoricCapital, DoricTriglyph, DoricTriglyphCorner, DoricMetope,
+            IonicCapital, CorinthianCapital, Architrave, ArchitraveCorner, CorniceLH, CorniceRH,
+            CorniceEndLH, CorniceEndRH, CorniceRidge, CorniceValley, CorniceBottom),
+        new ShapePage("Window",
+            WindowFrame, WindowCorner, WindowMullion),
+        new ShapePage("Arches",
+            ArchD1, ArchD2, ArchD3A, ArchD3B, ArchD3C, ArchD4A, ArchD4B, ArchD4C),
+        new ShapePage("Railings",
+            BalustradePlain, BalustradePlainOuterCorner, BalustradePlainInnerCorner,
+            BalustradePlainWithNewel, BalustradePlainEnd,
+            BanisterPlainTop, BanisterPlain, BanisterPlainBottom, BanisterPlainEnd, BanisterPlainInnerCorner,
+            BalustradeFancy, BalustradeFancyCorner, BalustradeFancyWithNewel, BalustradeFancyNewel,
+            BanisterFancyTop, BanisterFancy, BanisterFancyBottom, BanisterFancyEnd, BanisterFancyNewelTall),
+        new ShapePage("Other",
+            CladdingSheet, Slab, Stairs, StairsOuterCorner, StairsInnerCorner),
+    };
+    
+    public IInventory inventory = new InventoryBasic("Items", false, 2);
+    public int selectedPage = 0;
+    public int[] selectedSlots = new int[pages.length];
+    public boolean pendingMaterialUsage = false; // Material for the stack in the result slot
+                                          // has not yet been removed from the material slot
+                                          
+    // Loads the list of acceptable materials from the config file
+    /*
+    materials {
+        S:UnlocalizedNames <
+            tile.chisel.stained_glass
+            tile.chisel.glass
+        >
+    } 
+    */
+    private static List<String> acceptableMaterialsFromConfig = Arrays.asList(ArchitectureCraft.mod.config.get(
+                "materials", "UnlocalizedNames", new String[] {"tile.chisel.stained_glass"}).getStringList());
 
-	@Override
-	public void setInventorySlotContents(int i, ItemStack stack) {
-		super.setInventorySlotContents(i, stack);
-		updateResultSlot();
-	}
-	
-	@Override
-	public ItemStack decrStackSize(int slot, int amount) {
-		//System.out.printf("SawbenchTE.decrStackSize: %d by %d on %s\n", slot, amount, worldObj);
-		if (slot == resultSlot)
-		    usePendingMaterial();
-		ItemStack result = super.decrStackSize(slot, amount);
-		updateResultSlot();
-		return result;
-	}
-	
-	public ItemStack usePendingMaterial() {
-		//System.out.printf("SawbenchTE.usePendingMaterial: pmu = %s on %s\n", pendingMaterialUsage, worldObj);
+    public Shape getSelectedShape() {
+        if (selectedPage >= 0 && selectedPage < pages.length) {
+            int slot = selectedSlots[selectedPage];
+            if (slot >= 0 && slot < pages[selectedPage].size())
+                return pages[selectedPage].get(slot);
+        }
+        return null;
+    }
+    
+    @Override
+    protected IInventory getInventory() {
+        return inventory;
+    }
+
+    @Override
+    public void setInventorySlotContents(int i, ItemStack stack) {
+        super.setInventorySlotContents(i, stack);
+        updateResultSlot();
+    }
+    
+    @Override
+    public ItemStack decrStackSize(int slot, int amount) {
+        //System.out.printf("SawbenchTE.decrStackSize: %d by %d on %s\n", slot, amount, worldObj);
+        if (slot == resultSlot)
+            usePendingMaterial();
+        ItemStack result = super.decrStackSize(slot, amount);
+        updateResultSlot();
+        return result;
+    }
+    
+    public ItemStack usePendingMaterial() {
+        //System.out.printf("SawbenchTE.usePendingMaterial: pmu = %s on %s\n", pendingMaterialUsage, worldObj);
         ItemStack origMaterialStack = getStackInSlot(materialSlot);
-		if (pendingMaterialUsage) {
-			pendingMaterialUsage = false;
+        if (pendingMaterialUsage) {
+            pendingMaterialUsage = false;
             inventory.decrStackSize(materialSlot, materialMultiple());
-		}
-		return origMaterialStack;
-	}
+        }
+        return origMaterialStack;
+    }
 
-	public void returnUnusedMaterial(ItemStack origMaterialStack) {
-	    //if (!worldObj.isRemote)
-	    //    System.out.printf("SawbenchTE.returnUnusedMaterial: before: pmu = %s, material = %s, result = %s\n",
-	    //        pendingMaterialUsage, getStackInSlot(materialSlot), getStackInSlot(resultSlot));
-	    if (!pendingMaterialUsage) {
-	        ItemStack materialStack = getStackInSlot(materialSlot);
-	        ItemStack resultStack = getStackInSlot(resultSlot);
-	        int m = materialMultiple();
-	        int n = resultMultiple();
-	        if (resultStack != null && resultStack.stackSize == n) {
-	            if (materialStack != null)
-	                materialStack.stackSize += m;
-	            else {
-	                materialStack = origMaterialStack;
-	                materialStack.stackSize = m;
-	            }
-	            inventory.setInventorySlotContents(materialSlot, materialStack);
-	            pendingMaterialUsage = true;
-	        }
-	    }
-	    //if (!worldObj.isRemote)
-	    //    System.out.printf("SawbenchTE.returnUnusedMaterial: after: pmu = %s, material = %s, result = %s\n",
-	    //        pendingMaterialUsage, getStackInSlot(materialSlot), getStackInSlot(resultSlot));
- 	}
+    public void returnUnusedMaterial(ItemStack origMaterialStack) {
+        //if (!worldObj.isRemote)
+        //    System.out.printf("SawbenchTE.returnUnusedMaterial: before: pmu = %s, material = %s, result = %s\n",
+        //        pendingMaterialUsage, getStackInSlot(materialSlot), getStackInSlot(resultSlot));
+        if (!pendingMaterialUsage) {
+            ItemStack materialStack = getStackInSlot(materialSlot);
+            ItemStack resultStack = getStackInSlot(resultSlot);
+            int m = materialMultiple();
+            int n = resultMultiple();
+            if (resultStack != null && resultStack.stackSize == n) {
+                if (materialStack != null)
+                    materialStack.stackSize += m;
+                else {
+                    materialStack = origMaterialStack;
+                    materialStack.stackSize = m;
+                }
+                inventory.setInventorySlotContents(materialSlot, materialStack);
+                pendingMaterialUsage = true;
+            }
+        }
+        //if (!worldObj.isRemote)
+        //    System.out.printf("SawbenchTE.returnUnusedMaterial: after: pmu = %s, material = %s, result = %s\n",
+        //        pendingMaterialUsage, getStackInSlot(materialSlot), getStackInSlot(resultSlot));
+     }
 
-	/**
-	 * Returns an array containing the indices of the slots that can be accessed by automation on the given side of this
-	 * block.
-	 */
-	public int[] getAccessibleSlotsFromSide(int side) {
-		if (side == 1) // UP
-			return materialSideSlots;
-		else
-			return resultSideSlots;
-	}
+    /**
+     * Returns an array containing the indices of the slots that can be accessed by automation on the given side of this
+     * block.
+     */
+    public int[] getAccessibleSlotsFromSide(int side) {
+        if (side == 1) // UP
+            return materialSideSlots;
+        else
+            return resultSideSlots;
+    }
 
-	@Override
-	public void readFromNBT(NBTTagCompound tc) {
-		super.readFromNBT(tc);
-		selectedPage = tc.getInteger("Page");
-		int[] ss = tc.getIntArray("Slots");
-		if (ss != null)
-			for (int page = 0; page < pages.length; page++) {
-				int slot = page < ss.length ? ss[page] : 0;
-				selectedSlots[page] = slot >= 0 && slot < pages[page].size() ? slot : 0;
-		}
-		pendingMaterialUsage = tc.getBoolean("PMU");
-	}
+    @Override
+    public void readFromNBT(NBTTagCompound tc) {
+        super.readFromNBT(tc);
+        selectedPage = tc.getInteger("Page");
+        int[] ss = tc.getIntArray("Slots");
+        if (ss != null)
+            for (int page = 0; page < pages.length; page++) {
+                int slot = page < ss.length ? ss[page] : 0;
+                selectedSlots[page] = slot >= 0 && slot < pages[page].size() ? slot : 0;
+        }
+        pendingMaterialUsage = tc.getBoolean("PMU");
+    }
 
-	@Override
-	public void writeToNBT(NBTTagCompound tc) {
-		super.writeToNBT(tc);
-		tc.setInteger("Page", selectedPage);
-		tc.setIntArray("Slots", selectedSlots);
-		tc.setBoolean("PMU", pendingMaterialUsage);
-	}
-	
-	public void setSelectedShape(int page, int slot) {
-		if (page >= 0 && page < pages.length) {
-			selectedPage = page;
-			if (slot >= 0 && slot < pages[selectedPage].size()) {
-				selectedSlots[selectedPage] = slot;
-				markDirty();
-				updateResultSlot();
-				BaseMod.sendTileEntityUpdate(this);
-			}
-		}
-	}
+    @Override
+    public void writeToNBT(NBTTagCompound tc) {
+        super.writeToNBT(tc);
+        tc.setInteger("Page", selectedPage);
+        tc.setIntArray("Slots", selectedSlots);
+        tc.setBoolean("PMU", pendingMaterialUsage);
+    }
+    
+    public void setSelectedShape(int page, int slot) {
+        if (page >= 0 && page < pages.length) {
+            selectedPage = page;
+            if (slot >= 0 && slot < pages[selectedPage].size()) {
+                selectedSlots[selectedPage] = slot;
+                markDirty();
+                updateResultSlot();
+                BaseMod.sendTileEntityUpdate(this);
+            }
+        }
+    }
 
-	void updateResultSlot() {
-		//System.out.printf("SawbenchTE.updateResultSlot: pmu = %s on %s\n", pendingMaterialUsage, worldObj);
+    void updateResultSlot() {
+        //System.out.printf("SawbenchTE.updateResultSlot: pmu = %s on %s\n", pendingMaterialUsage, worldObj);
         //showMaterial();
-		ItemStack oldResult = getStackInSlot(resultSlot);
-		if (oldResult == null || pendingMaterialUsage) {
-			ItemStack resultStack = makeResultStack();
-			if (!ItemStack.areItemStacksEqual(resultStack, oldResult))
-				inventory.setInventorySlotContents(resultSlot, resultStack);
-			pendingMaterialUsage = resultStack != null;
-			//System.out.printf("SawbenchTE.updateResultSlot: now pmu = %s on %s\n", pendingMaterialUsage, worldObj);
-		}
-	}
-	
-	protected void showMaterial() {
-	    ItemStack stack = getStackInSlot(materialSlot);
-	    if (stack != null)
-	        System.out.printf("SawbenchTE: Material = %s\n", stack);
-	}
-	
-	protected ItemStack makeResultStack() {
+        ItemStack oldResult = getStackInSlot(resultSlot);
+        if (oldResult == null || pendingMaterialUsage) {
+            ItemStack resultStack = makeResultStack();
+            if (!ItemStack.areItemStacksEqual(resultStack, oldResult))
+                inventory.setInventorySlotContents(resultSlot, resultStack);
+            pendingMaterialUsage = resultStack != null;
+            //System.out.printf("SawbenchTE.updateResultSlot: now pmu = %s on %s\n", pendingMaterialUsage, worldObj);
+        }
+    }
+    
+    protected void showMaterial() {
+        ItemStack stack = getStackInSlot(materialSlot);
+        if (stack != null)
+            System.out.printf("SawbenchTE: Material = %s\n", stack);
+    }
+    
+    protected ItemStack makeResultStack() {
         Shape resultShape = getSelectedShape();
         if (resultShape != null) {
-			ItemStack materialStack = getStackInSlot(materialSlot);
+            ItemStack materialStack = getStackInSlot(materialSlot);
             if (materialStack != null && materialStack.stackSize >= resultShape.materialUsed) {
                 Item materialItem = materialStack.getItem();
                 if (materialItem instanceof ItemBlock) {
@@ -212,33 +227,33 @@ public class SawbenchTE extends BaseTileInventory {
     
     protected boolean isAcceptableMaterial(Block block) {
         if (block == Blocks.glass || block == Blocks.stained_glass || block instanceof BlockSlab ||
-            block.getUnlocalizedName().startsWith("tile.chisel.stained_glass"))
+            acceptableMaterialsFromConfig.contains(block.getUnlocalizedName()))
                 return true;
         return block.renderAsNormalBlock() && !block.hasTileEntity();
     }
 
-	int materialMultiple() {
-		int factor = 1;
-		ItemStack materialStack = getStackInSlot(materialSlot);
-		if (materialStack != null) {
-		    Block materialBlock = Block.getBlockFromItem(materialStack.getItem());
-		    if (materialBlock instanceof BlockSlab)
-		        factor = 2;
-		}
-		Shape shape = getSelectedShape();
-		if (shape != null)
-			return factor * shape.materialUsed;
-		return 0;
-	}
-	
-	int resultMultiple() {
-		//return productMadeForShape[selectedShape];
-		Shape shape = getSelectedShape();
-		if (shape != null)
-			return shape.itemsProduced;
-		return 0;
-	}
-	
+    int materialMultiple() {
+        int factor = 1;
+        ItemStack materialStack = getStackInSlot(materialSlot);
+        if (materialStack != null) {
+            Block materialBlock = Block.getBlockFromItem(materialStack.getItem());
+            if (materialBlock instanceof BlockSlab)
+                factor = 2;
+        }
+        Shape shape = getSelectedShape();
+        if (shape != null)
+            return factor * shape.materialUsed;
+        return 0;
+    }
+    
+    int resultMultiple() {
+        //return productMadeForShape[selectedShape];
+        Shape shape = getSelectedShape();
+        if (shape != null)
+            return shape.itemsProduced;
+        return 0;
+    }
+    
     /**
      * Returns true if automation can insert the given item in the given slot from the given side. Args: Slot, item,
      * side


### PR DESCRIPTION
materials

My editor swapped tabs for spaces so it looks like way more changes than it really was. I added 70-80 which reads an array of strings from a config file on initialization of acceptable material names. I left the original hard coded value of "tile.chisel.stained_glass" in as the default value in the instance that the config isn't present.

The other change is on line 230. I removed the hard coded value check and added a check to the string array from the config above. This should future proof the acceptable materials list by moving the list into a config file rather than hard coded values that would have to be recompiled.