### PR TITLE
Fixes to Shift Click Behavior in the Sawbench

### DIFF
--- a/src/main/java/gcewing/architecture/SawbenchContainer.java
+++ b/src/main/java/gcewing/architecture/SawbenchContainer.java
@@ -81,6 +81,7 @@ public class SawbenchContainer extends BaseContainer {
                 }
             }
         }
+        te.updateResultSlot();// update the result slot to make shift clicking new material in work smoothly
     }
 
     @ServerMessageHandler("SelectShape")

--- a/src/main/java/gcewing/architecture/SawbenchContainer.java
+++ b/src/main/java/gcewing/architecture/SawbenchContainer.java
@@ -43,8 +43,8 @@ public class SawbenchContainer extends BaseContainer {
         this.te = te;
         sawbenchSlotRange = new SlotRange();
         materialSlot = addSlotToContainer(new Slot(te, 0, inputSlotLeft, inputSlotTop));
-        resultSlot = addSlotToContainer(new SlotSawbenchResult(te, 1, outputSlotLeft, outputSlotTop));
         sawbenchSlotRange.end();
+        resultSlot = addSlotToContainer(new SlotSawbenchResult(te, 1, outputSlotLeft, outputSlotTop));
         addPlayerSlots(player, 8, guiHeight - 81);
     }
 


### PR DESCRIPTION
Fixed https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12692 with shift clicking material into the sawbench where you weren't able to pull out the result, and if you tried to add the same shape as the result, the item would be deleted.
