### PR TITLE
Support Lapis Caelestis, AntiBlocks and Neonite properly

### DIFF
--- a/src/main/java/gcewing/architecture/ArchitectureCraft.java
+++ b/src/main/java/gcewing/architecture/ArchitectureCraft.java
@@ -97,7 +97,7 @@ public class ArchitectureCraft {
     }
 
     void saveConfig() {
-        if (config.extended) config.save();
+        if (config.hasChanged()) config.save();
     }
 
     // --------------- Resources ----------------------------------------------------------

--- a/src/main/java/gcewing/architecture/ArchitectureCraftClient.java
+++ b/src/main/java/gcewing/architecture/ArchitectureCraftClient.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
-import cpw.mods.fml.common.registry.GameRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureManager;
@@ -32,6 +31,7 @@ import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.registry.GameRegistry;
 import gcewing.architecture.client.render.BlockRenderDispatcher;
 import gcewing.architecture.client.render.ICustomRenderer;
 import gcewing.architecture.client.render.ITexture;
@@ -343,19 +343,22 @@ public class ArchitectureCraftClient {
     // ------------------------------------------------------------------------------------------------
 
     private void initializeEmissiveBlocksSet() {
-        String[] emissiveBlockIds = ArchitectureCraft.mod.config.getStringList("EmissiveItemIDs", "materials",  new String[]{"ExtraUtilities:greenscreen", "chisel:antiBlock", "chisel:neonite"}, "Blocks that will be rendered with full brightness");
-        for(String id : emissiveBlockIds) {
+        String[] emissiveBlockIds = ArchitectureCraft.mod.config.getStringList(
+                "EmissiveItemIDs",
+                "materials",
+                new String[] { "ExtraUtilities:greenscreen", "chisel:antiBlock", "chisel:neonite" },
+                "Blocks that will be rendered with full brightness");
+        for (String id : emissiveBlockIds) {
             String[] parts = id.split(":");
-            if(parts.length >= 2) {
+            if (parts.length >= 2) {
                 Block b = GameRegistry.findBlock(parts[0], parts[1]);
 
-                if(b != null)
-                    emissiveBlocks.add(b);
+                if (b != null) emissiveBlocks.add(b);
             }
         }
     }
 
-    public boolean isBlockAndMetaEmissive(Block block, int meta){
+    public boolean isBlockAndMetaEmissive(Block block, int meta) {
         return emissiveBlocks.contains(block);
     }
 

--- a/src/main/java/gcewing/architecture/ArchitectureCraftClient.java
+++ b/src/main/java/gcewing/architecture/ArchitectureCraftClient.java
@@ -9,8 +9,10 @@ package gcewing.architecture;
 // import cpw.mods.fml.client.registry.RenderingRegistry;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
+import cpw.mods.fml.common.registry.GameRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureManager;
@@ -58,6 +60,7 @@ public class ArchitectureCraftClient {
 
     public static final ShapeRenderDispatch shapeRenderDispatch = new ShapeRenderDispatch();
     public static final PreviewRenderer previewRenderer = new PreviewRenderer();
+    final HashSet<Block> emissiveBlocks = new HashSet<>();
 
     public void preInit(FMLPreInitializationEvent e) {
         registerBlockRenderers();
@@ -73,6 +76,8 @@ public class ArchitectureCraftClient {
     public void postInit(FMLPostInitializationEvent e) {
         MinecraftForge.EVENT_BUS.register(previewRenderer);
         FMLCommonHandler.instance().bus().register(previewRenderer);
+
+        initializeEmissiveBlocksSet();
     }
 
     public ArchitectureCraftClient(ArchitectureCraft mod) {
@@ -334,4 +339,24 @@ public class ArchitectureCraftClient {
             }
         }
     }
+
+    // ------------------------------------------------------------------------------------------------
+
+    private void initializeEmissiveBlocksSet() {
+        String[] emissiveBlockIds = ArchitectureCraft.mod.config.getStringList("EmissiveItemIDs", "materials",  new String[]{"ExtraUtilities:greenscreen", "chisel:antiBlock", "chisel:neonite"}, "Blocks that will be rendered with full brightness");
+        for(String id : emissiveBlockIds) {
+            String[] parts = id.split(":");
+            if(parts.length >= 2) {
+                Block b = GameRegistry.findBlock(parts[0], parts[1]);
+
+                if(b != null)
+                    emissiveBlocks.add(b);
+            }
+        }
+    }
+
+    public boolean isBlockAndMetaEmissive(Block block, int meta){
+        return emissiveBlocks.contains(block);
+    }
+
 }

--- a/src/main/java/gcewing/architecture/client/render/RendererCladding.java
+++ b/src/main/java/gcewing/architecture/client/render/RendererCladding.java
@@ -41,6 +41,7 @@ public class RendererCladding implements ICustomRenderer {
                     IIcon sprite = getSpriteForBlockState(state);
                     if (sprite != null) {
                         ITexture texture = ArchitectureTexture.fromSprite(sprite);
+                        texture = ShapeRenderDispatch.checkBlendAndEmissive(state, texture);
                         IArchitectureModel model = ArchitectureCraft.mod.getModel("shape/cladding.objson");
                         model.render(t, target, texture);
                     }

--- a/src/main/java/gcewing/architecture/client/render/ShapeRenderDispatch.java
+++ b/src/main/java/gcewing/architecture/client/render/ShapeRenderDispatch.java
@@ -10,12 +10,12 @@ import static gcewing.architecture.compat.BlockCompatUtils.blockCanRenderInLayer
 import static gcewing.architecture.compat.BlockCompatUtils.getMetaFromBlockState;
 import static gcewing.architecture.compat.BlockCompatUtils.getSpriteForBlockState;
 
-import gcewing.architecture.ArchitectureCraft;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
+import gcewing.architecture.ArchitectureCraft;
 import gcewing.architecture.client.render.target.IRenderTarget;
 import gcewing.architecture.client.texture.ArchitectureTexture;
 import gcewing.architecture.common.tile.TileShape;
@@ -98,15 +98,14 @@ public class ShapeRenderDispatch implements ICustomRenderer {
         int blendColor = block.getRenderColor(meta);
         boolean needsBlending = (blendColor & 0xFFFFFF) != 0xFFFFFF;
 
-        if(needsBlending){
+        if (needsBlending) {
             double r = ((blendColor & 0xFF0000) >> 16) / 255.0;
             double g = ((blendColor & 0xFF00) >> 8) / 255.0;
             double b = (blendColor & 0xFF) / 255.0;
-            texture = texture.colored(r,g,b);
+            texture = texture.colored(r, g, b);
         }
 
-        if(blockAndMetaNeedsEmissive(block, meta))
-            texture = texture.emissive();
+        if (blockAndMetaNeedsEmissive(block, meta)) texture = texture.emissive();
 
         return texture;
     }

--- a/src/main/java/gcewing/architecture/client/render/target/RenderTargetWorld.java
+++ b/src/main/java/gcewing/architecture/client/render/target/RenderTargetWorld.java
@@ -10,6 +10,7 @@ import static gcewing.architecture.util.Utils.ifloor;
 import static gcewing.architecture.util.Utils.iround;
 import static java.lang.Math.floor;
 
+import gcewing.architecture.client.render.ITexture;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.Tessellator;
@@ -33,6 +34,7 @@ public class RenderTargetWorld extends RenderTargetBase {
     protected boolean renderingOccurred;
     protected float vr, vg, vb, va; // Colour to be applied to next vertex
     protected int vlm1, vlm2; // Light map values to be applied to next vertex
+    protected boolean emissive;
 
     public RenderTargetWorld(IBlockAccess world, BlockPos pos, Tessellator tess, IIcon overrideIcon) {
         super(pos.getX(), pos.getY(), pos.getZ(), overrideIcon);
@@ -61,11 +63,19 @@ public class RenderTargetWorld extends RenderTargetBase {
         renderingOccurred = true;
     }
 
+    @Override
+    public void setTexture(ITexture tex) {
+        if(texture != tex) {
+            super.setTexture(tex);
+            emissive = tex.isEmissive();
+        }
+    }
+
     // -----------------------------------------------------------------------------------------
 
     protected void lightVertex(Vector3 p) {
         // TODO: Colour multiplier
-        if (ao) aoLightVertex(p);
+        if (ao && !emissive) aoLightVertex(p);
         else brLightVertex(p);
     }
 
@@ -117,6 +127,10 @@ public class RenderTargetWorld extends RenderTargetBase {
     }
 
     protected void brLightVertex(Vector3 p) {
+        if(emissive) {
+            setLight(1.0f, 240);
+            return;
+        }
         Vector3 n = normal;
         BlockPos pos;
         if (axisAlignedNormal) pos = new BlockPos(

--- a/src/main/java/gcewing/architecture/client/render/target/RenderTargetWorld.java
+++ b/src/main/java/gcewing/architecture/client/render/target/RenderTargetWorld.java
@@ -10,13 +10,13 @@ import static gcewing.architecture.util.Utils.ifloor;
 import static gcewing.architecture.util.Utils.iround;
 import static java.lang.Math.floor;
 
-import gcewing.architecture.client.render.ITexture;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
+import gcewing.architecture.client.render.ITexture;
 import gcewing.architecture.compat.BlockPos;
 import gcewing.architecture.compat.Vector3;
 
@@ -65,7 +65,7 @@ public class RenderTargetWorld extends RenderTargetBase {
 
     @Override
     public void setTexture(ITexture tex) {
-        if(texture != tex) {
+        if (texture != tex) {
             super.setTexture(tex);
             emissive = tex.isEmissive();
         }
@@ -127,7 +127,7 @@ public class RenderTargetWorld extends RenderTargetBase {
     }
 
     protected void brLightVertex(Vector3 p) {
-        if(emissive) {
+        if (emissive) {
             setLight(1.0f, 240);
             return;
         }

--- a/src/main/java/gcewing/architecture/common/tile/TileSawbench.java
+++ b/src/main/java/gcewing/architecture/common/tile/TileSawbench.java
@@ -265,7 +265,7 @@ public class TileSawbench extends TileArchitectureInventory implements IRestrict
      */
     private static final List<String> acceptableMaterialsFromConfig = Arrays.asList(
             ArchitectureCraft.mod.config
-                    .get("materials", "UnlocalizedNames", new String[] { "tile.chisel.stained_glass" })
+                    .get("materials", "UnlocalizedNames", new String[] { "tile.chisel.stained_glass", "tile.extrautils:greenscreen" })
                     .getStringList());
 
     public Shape getSelectedShape() {

--- a/src/main/java/gcewing/architecture/common/tile/TileSawbench.java
+++ b/src/main/java/gcewing/architecture/common/tile/TileSawbench.java
@@ -265,7 +265,10 @@ public class TileSawbench extends TileArchitectureInventory implements IRestrict
      */
     private static final List<String> acceptableMaterialsFromConfig = Arrays.asList(
             ArchitectureCraft.mod.config
-                    .get("materials", "UnlocalizedNames", new String[] { "tile.chisel.stained_glass", "tile.extrautils:greenscreen" })
+                    .get(
+                            "materials",
+                            "UnlocalizedNames",
+                            new String[] { "tile.chisel.stained_glass", "tile.extrautils:greenscreen" })
                     .getStringList());
 
     public Shape getSelectedShape() {


### PR DESCRIPTION
This adds support for full-bright blocks like Lapis Caelestis (greenscreen) from Extra Utilities, and improves rendering of AntiBlocks and Neonite from Chisel.

NOTE: This adds blocks based on a config whitelist! You will probably need to regenerate your config file! In particular, you'll need `tile.extrautils:greenscreen` in your `UnlocalizedNames` list for Lapis Caelestis.

As a side note, TileSawbench has this:
```java
    private static final List<String> acceptableMaterialsFromConfig = Arrays.asList(
            ArchitectureCraft.mod.config
                    .get(
                            "materials",
                            "UnlocalizedNames",
                            new String[] { "tile.chisel.stained_glass", "tile.extrautils:greenscreen" })
                    .getStringList());
```
However, I'm guessing this class is never initialized before postInit(), so this setting is not currently getting saved. A refactoring of config handling may be warranted, but that might be outside of the scope of this PR.