### PR TITLE
Schematica crash workaround.

### DIFF
--- a/src/main/java/gcewing/architecture/common/item/ArchitectureItemBlock.java
+++ b/src/main/java/gcewing/architecture/common/item/ArchitectureItemBlock.java
@@ -39,6 +39,7 @@ public class ArchitectureItemBlock extends ItemBlock implements IHasModel {
     @Override
     public boolean onItemUse(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side,
             float hitX, float hitY, float hitZ) {
+        if (side > 5) side = 0;
         Block block = world.getBlock(x, y, z);
         if (!block.isReplaceable(world, x, y, z)) {
             if (side == 0) --y;


### PR DESCRIPTION
Workaround for https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20327.

Ideally someone should figure out what is passing an invalid side (6) to the method and fix it at the source; but the call stack only contains vanilla methods and I have no clue where to even start looking.

Tested in full pack, haven't crashed with the fix in over an hour. (Without it I would crash in seconds to minutes any time I would place AC blocks with Schematica.)