### PR TITLE
Fix flipped bottom face uv when hodgepodge mc fix is enabled

### DIFF
--- a/src/main/java/gcewing/architecture/ArchitectureCraftClient.java
+++ b/src/main/java/gcewing/architecture/ArchitectureCraftClient.java
@@ -19,6 +19,7 @@ import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
+import net.minecraft.launchwrapper.Launch;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.IBlockAccess;
@@ -64,6 +65,7 @@ public class ArchitectureCraftClient {
     public static final PreviewRenderer previewRenderer = new PreviewRenderer();
     final HashSet<Block> emissiveBlocks = new HashSet<>();
     public static AngelicaCompat angelicaCompat;
+    public static boolean enabledHodgepodgeBottomFaceUVFix;
 
     public void preInit(FMLPreInitializationEvent e) {
         registerBlockRenderers();
@@ -85,6 +87,9 @@ public class ArchitectureCraftClient {
         if (Loader.isModLoaded("angelica")) {
             angelicaCompat = new AngelicaCompat();
         }
+
+        enabledHodgepodgeBottomFaceUVFix = (boolean) Launch.blackboard
+                .getOrDefault("hodgepodge.FixesConfig.fixBottomFaceUV", Boolean.FALSE);
     }
 
     public ArchitectureCraftClient(ArchitectureCraft mod) {

--- a/src/main/java/gcewing/architecture/ArchitectureCraftClient.java
+++ b/src/main/java/gcewing/architecture/ArchitectureCraftClient.java
@@ -65,7 +65,8 @@ public class ArchitectureCraftClient {
     public static final PreviewRenderer previewRenderer = new PreviewRenderer();
     final HashSet<Block> emissiveBlocks = new HashSet<>();
     public static AngelicaCompat angelicaCompat;
-    public static boolean enabledHodgepodgeBottomFaceUVFix;
+    public static final boolean enabledHodgepodgeBottomFaceUVFix = (boolean) Launch.blackboard
+            .getOrDefault("hodgepodge.FixesConfig.fixBottomFaceUV", Boolean.FALSE);
 
     public void preInit(FMLPreInitializationEvent e) {
         registerBlockRenderers();
@@ -87,9 +88,6 @@ public class ArchitectureCraftClient {
         if (Loader.isModLoaded("angelica")) {
             angelicaCompat = new AngelicaCompat();
         }
-
-        enabledHodgepodgeBottomFaceUVFix = (boolean) Launch.blackboard
-                .getOrDefault("hodgepodge.FixesConfig.fixBottomFaceUV", Boolean.FALSE);
     }
 
     public ArchitectureCraftClient(ArchitectureCraft mod) {

--- a/src/main/java/gcewing/architecture/client/render/target/RenderTargetBase.java
+++ b/src/main/java/gcewing/architecture/client/render/target/RenderTargetBase.java
@@ -137,30 +137,34 @@ public abstract class RenderTargetBase implements IRenderTarget {
         double z = p.z - blockZ;
 
         double u, v;
-        v = switch (face) {
-            case DOWN, UP -> {
+        switch (face) {
+            case UP -> {
                 u = x;
-                yield z;
+                v = z;
+            }
+            case DOWN -> {
+                u = 1 - x;
+                v = z;
             }
             case NORTH -> {
                 u = 1 - x;
-                yield 1 - y;
+                v = 1 - y;
             }
             case SOUTH -> {
                 u = x;
-                yield 1 - y;
+                v = 1 - y;
             }
             case WEST -> {
                 u = 1 - z;
-                yield 1 - y;
+                v = 1 - y;
             }
             case EAST -> {
                 u = z;
-                yield 1 - y;
+                v = 1 - y;
             }
             default -> {
                 u = 0;
-                yield 0;
+                v = 0;
             }
         };
         addUVVertex(p, u, v);

--- a/src/main/java/gcewing/architecture/client/render/target/RenderTargetBase.java
+++ b/src/main/java/gcewing/architecture/client/render/target/RenderTargetBase.java
@@ -9,6 +9,7 @@ package gcewing.architecture.client.render.target;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.IIcon;
 
+import gcewing.architecture.ArchitectureCraftClient;
 import gcewing.architecture.client.render.ITexture;
 import gcewing.architecture.client.texture.ArchitectureTexture;
 import gcewing.architecture.compat.Vector3;
@@ -143,7 +144,11 @@ public abstract class RenderTargetBase implements IRenderTarget {
                 v = z;
             }
             case DOWN -> {
-                u = 1 - x;
+                if (ArchitectureCraftClient.enabledHodgepodgeBottomFaceUVFix) {
+                    u = 1 - x;
+                } else {
+                    u = x;
+                }
                 v = z;
             }
             case NORTH -> {


### PR DESCRIPTION
For GTNewHorizons/Hodgepodge/pull/676

Before fix (there is a glow block on the right)
<img width="935" height="420" alt="image" src="https://github.com/user-attachments/assets/47b5b16c-b69d-4bdb-8805-da311f93489c" />

After fix
<img width="959" height="472" alt="image" src="https://github.com/user-attachments/assets/07053d90-d9eb-42a3-9766-913cb9788252" />
