### PR TITLE
Fix ShapeItem losing its display name when used with tooltip mods

### DIFF
--- a/src/main/java/gcewing/architecture/common/shape/ShapeItem.java
+++ b/src/main/java/gcewing/architecture/common/shape/ShapeItem.java
@@ -74,13 +74,24 @@ public class ShapeItem extends ArchitectureItemBlock {
     }
 
     @Override
-    public void addInformation(ItemStack stack, EntityPlayer player, List lines, boolean par4) {
+    public String getItemStackDisplayName(ItemStack stack) {
         NBTTagCompound tag = stack.getTagCompound();
         if (tag != null) {
             int id = tag.getInteger("Shape");
             Shape shape = Shape.forId(id);
-            if (shape != null) lines.set(0, GuiText.valueOf(GuiText.class, shape.name()).getLocal());
-            else lines.set(0, lines.get(0) + " (" + id + ")");
+            if (shape != null) {
+                return GuiText.valueOf(GuiText.class, shape.name()).getLocal();
+            } else {
+                return super.getItemStackDisplayName(stack) + " (" + id + ")";
+            }
+        }
+        return super.getItemStackDisplayName(stack);
+    }
+
+    @Override
+    public void addInformation(ItemStack stack, EntityPlayer player, List lines, boolean par4) {
+        NBTTagCompound tag = stack.getTagCompound();
+        if (tag != null) {
             Block baseBlock = Block.getBlockFromName(tag.getString("BaseName"));
             int baseMetadata = tag.getInteger("BaseData");
             if (baseBlock != null) lines.add(Utils.displayNameOfBlock(baseBlock, baseMetadata));


### PR DESCRIPTION
ShapeItem was overriding the item name by patching lines[0] inside addInformation() instead of overriding getItemStackDisplayName().

This worked with vanilla tooltip rendering because the tooltip list is fully built before being displayed. However, mods like ChromaticTooltips call stack.getDisplayName() directly to extract the item title, bypassing addInformation() entirely. This caused shaped blocks to always show "Architectural Block" as their name instead of the actual shape name (e.g. "Slope B End").

Additionally, ChromaticTooltips internally adds a temporary displayName placeholder at lines[0] before calling addInformation(), then removes it afterwards. Since ShapeItem was replacing that placeholder with the correct shape name, the shape name was getting removed along with it.

Fix by overriding getItemStackDisplayName() to return the localized shape name from NBT, which is the correct Minecraft API contract for customizing item display names. The lines.set(0, ...) calls in addInformation() are removed as they are now redundant.

|Befor|After|
|-|-|
|<img width="442" height="156" alt="image" src="https://github.com/user-attachments/assets/f6fd8310-e837-46ff-bac1-5b0dcc063d72" />|<img width="464" height="214" alt="image" src="https://github.com/user-attachments/assets/3d6b831e-940a-4889-b92c-3dc6d4490a2b" />|