### PR TITLE
Add a message for updating block orientation

### DIFF
--- a/src/main/java/gcewing/architecture/ArchitectureCraft.java
+++ b/src/main/java/gcewing/architecture/ArchitectureCraft.java
@@ -27,6 +27,7 @@ import gcewing.architecture.client.render.model.IArchitectureModel;
 import gcewing.architecture.client.render.model.ObjJsonModel;
 import gcewing.architecture.common.config.ArchitectConfiguration;
 import gcewing.architecture.common.network.DataChannel;
+import gcewing.architecture.common.network.OrientationHandler;
 
 @Mod(
         modid = ArchitectureCraft.MOD_ID,
@@ -53,7 +54,7 @@ public class ArchitectureCraft {
 
     public ArchitectureCraft() {
         super();
-        channel = new DataChannel(MOD_ID);
+        channel = new DataChannel(MOD_ID, new OrientationHandler());
     }
 
     @Mod.EventHandler

--- a/src/main/java/gcewing/architecture/common/network/OrientationHandler.java
+++ b/src/main/java/gcewing/architecture/common/network/OrientationHandler.java
@@ -1,0 +1,30 @@
+package gcewing.architecture.common.network;
+
+import net.minecraft.entity.player.EntityPlayer;
+
+import gcewing.architecture.common.tile.TileShape;
+import gcewing.architecture.compat.BlockPos;
+
+public class OrientationHandler {
+
+    @ServerMessageHandler("SetOrientation")
+    public void onSetOrientation(EntityPlayer player, ChannelInput data) {
+        int x = data.readInt();
+        int y = data.readInt();
+        int z = data.readInt();
+        byte side = data.readByte();
+        byte turn = data.readByte();
+
+        if (side < 0 || side > 5 || turn < 0 || turn > 3) return;
+
+        double dist = player.getDistanceSq(x + 0.5, y + 0.5, z + 0.5);
+        if (dist > 100.0) return;
+
+        TileShape te = TileShape.get(player.worldObj, new BlockPos(x, y, z));
+        if (te != null) {
+            te.setSide(side);
+            te.setTurn(turn);
+            te.markChanged();
+        }
+    }
+}


### PR DESCRIPTION
Adds a SetOrientation message for updating a block's orientation after placement.

This enables other mods to add support for auto-building/schematics with ArchitectureCraft blocks.

I have also submitted a PR to Schematica, which uses this change to enable correct pasting of schematics containing ArchitectureCraft blocks:
https://github.com/GTNewHorizons/Schematica/pull/27