### PR TITLE
Revert glow shapes to blockShapeSE block type

### DIFF
--- a/src/main/java/gcewing/architecture/common/block/BlockShape.java
+++ b/src/main/java/gcewing/architecture/common/block/BlockShape.java
@@ -31,6 +31,7 @@ import net.minecraft.world.World;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import gcewing.architecture.ArchitectureCraft;
 import gcewing.architecture.common.tile.TileShape;
 import gcewing.architecture.compat.BlockCompatUtils;
 import gcewing.architecture.compat.BlockPos;
@@ -182,11 +183,8 @@ public class BlockShape extends BlockArchitecture<TileShape> {
             TileEntity te, int fortune) {
         ArrayList<ItemStack> result = new ArrayList<>();
         if (te instanceof TileShape ste) {
-            ItemStack stack = ste.shape.kind.newStack(
-                    ste.shape,
-                    ste.baseBlockState,
-                    1,
-                    state.getBlock().getUnlocalizedName().contains("shapeSE"));
+            boolean isGlowBlock = this == ArchitectureCraft.content.blockShapeSE;
+            ItemStack stack = ste.shape.kind.newStack(ste.shape, ste.baseBlockState, 1, isGlowBlock);
             result.add(stack);
             if (ste.secondaryBlockState != null) {
                 stack = ste.shape.kind.newSecondaryMaterialStack(ste.secondaryBlockState);
@@ -269,7 +267,7 @@ public class BlockShape extends BlockArchitecture<TileShape> {
 
     @Override
     public int getLightValue(IBlockAccess world, int x, int y, int z) {
-        return world.getBlockMetadata(x, y, z);
+        return this == ArchitectureCraft.content.blockShapeSE ? 15 : 0;
     }
 
 }

--- a/src/main/java/gcewing/architecture/common/item/ItemGlowBrush.java
+++ b/src/main/java/gcewing/architecture/common/item/ItemGlowBrush.java
@@ -53,10 +53,6 @@ public class ItemGlowBrush extends ItemArchitecture {
         TileShape newTE = TileShape.get(world, pos);
         if (newTE != null) {
             newTE.readFromNBT(savedNBT);
-            // Restore correct coordinates overwritten by readFromNBT
-            newTE.xCoord = pos.x;
-            newTE.yCoord = pos.y;
-            newTE.zCoord = pos.z;
             newTE.markChanged();
         }
 

--- a/src/main/java/gcewing/architecture/common/item/ItemGlowBrush.java
+++ b/src/main/java/gcewing/architecture/common/item/ItemGlowBrush.java
@@ -6,11 +6,13 @@
 
 package gcewing.architecture.common.item;
 
+import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.World;
 
 import gcewing.architecture.ArchitectureCraft;
@@ -31,23 +33,34 @@ public class ItemGlowBrush extends ItemArchitecture {
     @Override
     public boolean onItemUse(ItemStack stack, EntityPlayer player, World world, BlockPos pos, EnumFacing side,
             float hitX, float hitY, float hitZ) {
+        if (world.isRemote) return false;
+
         TileShape te = TileShape.get(world, pos);
-        if (te != null) {
-            NBTTagCompound shape = new NBTTagCompound();
-            te.writeToNBT(shape);
-            if (player.isSneaking()) {
-                // set the block to the non-glowing variant, and set it's meta to 0 for it to give no light
-                world.setBlock(pos.x, pos.y, pos.z, ArchitectureCraft.content.blockShape, 0, 3);
-            } else {
-                // set the block to the glow variant, and set it's meta to 15 for it to actual give off light
-                world.setBlock(pos.x, pos.y, pos.z, ArchitectureCraft.content.blockShapeSE, 15, 3);
-            }
-            TileShape newTile = TileShape.get(world, pos);
-            if (newTile != null) {
-                newTile.readFromNBT(shape);
-            }
-            return true;
+        if (te == null) return false;
+
+        Block currentBlock = world.getBlock(pos.x, pos.y, pos.z);
+        boolean makingGlow = !player.isSneaking();
+        boolean alreadyGlow = currentBlock == ArchitectureCraft.content.blockShapeSE;
+        if (makingGlow == alreadyGlow) return true;
+
+        // Save all shape state
+        NBTTagCompound savedNBT = new NBTTagCompound();
+        te.writeToNBT(savedNBT);
+
+        Block newBlock = makingGlow ? ArchitectureCraft.content.blockShapeSE : ArchitectureCraft.content.blockShape;
+        world.setBlock(pos.x, pos.y, pos.z, newBlock, 0, 3);
+
+        TileShape newTE = TileShape.get(world, pos);
+        if (newTE != null) {
+            newTE.readFromNBT(savedNBT);
+            // Restore correct coordinates overwritten by readFromNBT
+            newTE.xCoord = pos.x;
+            newTE.yCoord = pos.y;
+            newTE.zCoord = pos.z;
+            newTE.markChanged();
         }
-        return false;
+
+        world.updateLightByType(EnumSkyBlock.Block, pos.x, pos.y, pos.z);
+        return true;
     }
 }

--- a/src/main/java/gcewing/architecture/common/shape/ShapeItem.java
+++ b/src/main/java/gcewing/architecture/common/shape/ShapeItem.java
@@ -13,6 +13,8 @@ import static gcewing.architecture.compat.Vector3.getDirectionVec;
 import static gcewing.architecture.util.Utils.oppositeFacing;
 
 import java.util.List;
+
+import net.minecraft.world.EnumSkyBlock;
 import java.util.Random;
 
 import net.minecraft.block.Block;
@@ -23,6 +25,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
 
+import gcewing.architecture.ArchitectureCraft;
 import gcewing.architecture.client.gui.widget.GuiText;
 import gcewing.architecture.common.item.ArchitectureItemBlock;
 import gcewing.architecture.common.tile.TileShape;
@@ -63,6 +66,9 @@ public class ShapeItem extends ArchitectureItemBlock {
                 IBlockState nstate = getWorldBlockState(world, npos);
                 TileEntity nte = getWorldTileEntity(world, npos);
                 te.shape.orientOnPlacement(player, te, npos, nstate, nte, face, hit);
+            }
+            if (Block.getBlockFromItem(stack.getItem()) == ArchitectureCraft.content.blockShapeSE) {
+                world.updateLightByType(EnumSkyBlock.Block, pos.x, pos.y, pos.z);
             }
         }
         return true;

--- a/src/main/java/gcewing/architecture/common/shape/ShapeItem.java
+++ b/src/main/java/gcewing/architecture/common/shape/ShapeItem.java
@@ -13,8 +13,6 @@ import static gcewing.architecture.compat.Vector3.getDirectionVec;
 import static gcewing.architecture.util.Utils.oppositeFacing;
 
 import java.util.List;
-
-import net.minecraft.world.EnumSkyBlock;
 import java.util.Random;
 
 import net.minecraft.block.Block;
@@ -23,6 +21,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.World;
 
 import gcewing.architecture.ArchitectureCraft;

--- a/src/main/java/gcewing/architecture/common/shape/ShapeKind.java
+++ b/src/main/java/gcewing/architecture/common/shape/ShapeKind.java
@@ -80,29 +80,18 @@ public abstract class ShapeKind {
 
     public ItemStack newStack(Shape shape, Block materialBlock, int materialMeta, int stackSize) {
         TileShape te = new TileShape(shape, materialBlock, materialMeta);
-        int light = materialBlock.getLightValue();
-        ItemStack result = TileArchitecture
-                .blockStackWithTileEntity(ArchitectureCraft.content.blockShape, stackSize, light, te);
-        return result;
+        return TileArchitecture.blockStackWithTileEntity(ArchitectureCraft.content.blockShape, stackSize, 0, te);
     }
 
     public ItemStack newStack(Shape shape, Block materialBlock, int materialMeta, int stackSize,
             boolean shaderEmissive) {
-        TileShape te = new TileShape(shape, materialBlock, materialMeta);
-        int light = materialBlock.getLightValue();
         if (shape.id == Shape.CladdingSheet.id) {
             return ArchitectureCraft.content.itemCladding.newStack(materialBlock, materialMeta, stackSize);
         }
 
-        if (shaderEmissive) {
-            light = 15;
-            ItemStack result = TileArchitecture
-                    .blockStackWithTileEntity(ArchitectureCraft.content.blockShapeSE, stackSize, light, te);
-            return result;
-        }
-        ItemStack result = TileArchitecture
-                .blockStackWithTileEntity(ArchitectureCraft.content.blockShape, stackSize, light, te);
-        return result;
+        TileShape te = new TileShape(shape, materialBlock, materialMeta);
+        Block block = shaderEmissive ? ArchitectureCraft.content.blockShapeSE : ArchitectureCraft.content.blockShape;
+        return TileArchitecture.blockStackWithTileEntity(block, stackSize, 0, te);
     }
 
     public boolean orientOnPlacement(EntityPlayer player, TileShape te, BlockPos npos, IBlockState nstate,

--- a/src/main/java/gcewing/architecture/common/tile/TileShape.java
+++ b/src/main/java/gcewing/architecture/common/tile/TileShape.java
@@ -41,7 +41,6 @@ public class TileShape extends TileArchitecture {
     public IBlockState secondaryBlockState;
     public int disabledConnections;
     private byte offsetX;
-
     public static TileShape get(IBlockAccess world, BlockPos pos) {
         if (world != null) {
             TileEntity te = getWorldTileEntity(world, pos);

--- a/src/main/java/gcewing/architecture/common/tile/TileShape.java
+++ b/src/main/java/gcewing/architecture/common/tile/TileShape.java
@@ -41,6 +41,7 @@ public class TileShape extends TileArchitecture {
     public IBlockState secondaryBlockState;
     public int disabledConnections;
     private byte offsetX;
+
     public static TileShape get(IBlockAccess world, BlockPos pos) {
         if (world != null) {
             TileEntity te = getWorldTileEntity(world, pos);


### PR DESCRIPTION
isGlowing flag in TileEntity NBT caused item identity mismatch when external tools (e.g. Matter Manipulator) scanned glow blocks - they read block meta=0 but the item in inventory had a different NBT signature, so the item was never found.

Glow state is now encoded in block type again (blockShapeSE vs blockShape), which is how it worked before PR #19. GlowBrush swaps the block in-world while copying all TileShape data (shape, material, orientation, cladding) via NBT transfer. Drops and light value now derive from block type rather than a TE flag.