### PR TITLE
Fix isSideSolid for shape blocks

### DIFF
--- a/src/main/java/gcewing/architecture/common/block/BlockShape.java
+++ b/src/main/java/gcewing/architecture/common/block/BlockShape.java
@@ -76,6 +76,32 @@ public class BlockShape extends BlockArchitecture<TileShape> {
     }
 
     @Override
+    public boolean isSideSolid(IBlockAccess world, BlockPos pos, EnumFacing side) {
+        TileEntity te = getWorldTileEntity(world, pos);
+        if (!(te instanceof TileShape)) return false;
+        TileShape ts = (TileShape) te;
+        if (ts.shape == null) return false;
+        int occ = ts.shape.occlusionMask;
+        if ((occ & 0xff00) != 0) return false; // non-cubelet collision format
+        // Transform the world-space face direction into shape-local space
+        Trans3 t = Trans3.sideTurn(ts.side, ts.turn);
+        EnumFacing localFace = t.it(side);
+        // Check that all 4 cubelets on the requested face are filled
+        // Cubelet bit layout: bit = (x<<0)|(z<<1)|(y<<2), positive axis = 1, negative = 0
+        int faceMask;
+        switch (localFace) {
+            case DOWN:  faceMask = 0x0f; break; // y- : bits 0-3 (i&4==0)
+            case UP:    faceMask = 0xf0; break; // y+ : bits 4-7 (i&4!=0)
+            case NORTH: faceMask = 0x33; break; // z- : bits where i&2==0
+            case SOUTH: faceMask = 0xcc; break; // z+ : bits where i&2!=0
+            case WEST:  faceMask = 0x55; break; // x- : bits where i&1==0
+            case EAST:  faceMask = 0xaa; break; // x+ : bits where i&1!=0
+            default: return false;
+        }
+        return (occ & faceMask) == faceMask;
+    }
+
+    @Override
     public boolean isOpaqueCube() {
         return false;
     }

--- a/src/main/java/gcewing/architecture/common/block/BlockShape.java
+++ b/src/main/java/gcewing/architecture/common/block/BlockShape.java
@@ -90,13 +90,26 @@ public class BlockShape extends BlockArchitecture<TileShape> {
         // Cubelet bit layout: bit = (x<<0)|(z<<1)|(y<<2), positive axis = 1, negative = 0
         int faceMask;
         switch (localFace) {
-            case DOWN:  faceMask = 0x0f; break; // y- : bits 0-3 (i&4==0)
-            case UP:    faceMask = 0xf0; break; // y+ : bits 4-7 (i&4!=0)
-            case NORTH: faceMask = 0x33; break; // z- : bits where i&2==0
-            case SOUTH: faceMask = 0xcc; break; // z+ : bits where i&2!=0
-            case WEST:  faceMask = 0x55; break; // x- : bits where i&1==0
-            case EAST:  faceMask = 0xaa; break; // x+ : bits where i&1!=0
-            default: return false;
+            case DOWN:
+                faceMask = 0x0f;
+                break; // y- : bits 0-3 (i&4==0)
+            case UP:
+                faceMask = 0xf0;
+                break; // y+ : bits 4-7 (i&4!=0)
+            case NORTH:
+                faceMask = 0x33;
+                break; // z- : bits where i&2==0
+            case SOUTH:
+                faceMask = 0xcc;
+                break; // z+ : bits where i&2!=0
+            case WEST:
+                faceMask = 0x55;
+                break; // x- : bits where i&1==0
+            case EAST:
+                faceMask = 0xaa;
+                break; // x+ : bits where i&1!=0
+            default:
+                return false;
         }
         return (occ & faceMask) == faceMask;
     }

--- a/src/main/java/gcewing/architecture/common/shape/Shape.java
+++ b/src/main/java/gcewing/architecture/common/shape/Shape.java
@@ -151,10 +151,10 @@ public enum Shape {
     BanisterPlainInnerCorner(88, "Plain Banister Inner Corner", Model("balustrade_stair_plain_inner_corner"),
             Unilateral, 1, 6, 0x0),
 
-    Slab(90, "Slab", Model("slab"), Quadrilateral, 1, 2, 0x0),
-    Stairs(91, "Stairs", Model("stairs", lrStraight), Bilateral, 3, 4, 0x0),
-    StairsOuterCorner(92, "Stairs Outer Corner", Model("stairs_outer_corner", lrCorner), Unilateral, 2, 3, 0x0),
-    StairsInnerCorner(93, "Stairs Inner Corner", Model("stairs_inner_corner", rlCorner), Unilateral, 1, 1, 0x0),
+    Slab(90, "Slab", Model("slab"), Quadrilateral, 1, 2, 0x0f),
+    Stairs(91, "Stairs", Model("stairs", lrStraight), Bilateral, 3, 4, 0xcf),
+    StairsOuterCorner(92, "Stairs Outer Corner", Model("stairs_outer_corner", lrCorner), Unilateral, 2, 3, 0x4f),
+    StairsInnerCorner(93, "Stairs Inner Corner", Model("stairs_inner_corner", rlCorner), Unilateral, 1, 1, 0xdf),
 
     SlopeTileA1(94, "Slope A Start", Roof, Bilateral, 1, 1, 0xcf),
     SlopeTileA2(95, "Slope A End", Roof, Bilateral, 1, 3, 0x0f),
@@ -175,8 +175,8 @@ public enum Shape {
     SlopeTileC3SE(110, "Slope C 3(Glow)", Roof, Bilateral, 1, 3, 0x0f),
     SlopeTileC4SE(111, "Slope C 4(Glow)", Roof, Bilateral, 1, 4, 0x0f),
     RoofTileSE(112, "Roof Tile(Glow)", Roof, Bilateral, 1, 2, 0xcf),
-    SquareSE(113, "Square(Glow)", Model("square"), Quadrilateral, 1, 1, 0x0),
-    SlabSE(114, "Slab(Glow)", Model("slab"), Quadrilateral, 1, 2, 0x0),
+    SquareSE(113, "Square(Glow)", Model("square"), Quadrilateral, 1, 1, 0xff),
+    SlabSE(114, "Slab(Glow)", Model("slab"), Quadrilateral, 1, 2, 0x0f),
     AngledRoofRidge(115, "Angled Roof Ridge", Model("angled_roof_ridge"), Bilateral, 1, 4, 0x0f),
     DoubleRoofTile(116, "Double Roof Tile", Model("double_roof_tile"), Bilateral, 1, 2, 0xcf),;
 


### PR DESCRIPTION
\`isSideSolid\` was delegating to vanilla \`Block.isSideSolid\` which checks \`isOpaqueCube()\` -- always false for shape blocks, so torches, levers and redstone couldn't be placed on them. Fixed by overriding it in \`BlockShape\` to transform the requested face into shape-local space via \`Trans3\` and check the cubelet mask. Also corrected wrong \`occlusionMask\` values on several shapes that had \`0x0\` despite their collision geometry being non-empty.