### PR TITLE
fix preview renderer using wrong texture and no lightmap

### DIFF
--- a/src/main/java/gcewing/architecture/client/render/PreviewRenderer.java
+++ b/src/main/java/gcewing/architecture/client/render/PreviewRenderer.java
@@ -2,8 +2,10 @@ package gcewing.architecture.client.render;
 
 import static gcewing.architecture.compat.BlockCompatUtils.getWorldBlockState;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -86,10 +88,18 @@ public class PreviewRenderer {
             double tY = player.lastTickPosY + (player.posY - player.lastTickPosY) * (double) e.partialTicks;
             double tZ = player.lastTickPosZ + (player.posZ - player.lastTickPosZ) * (double) e.partialTicks;
 
+            // The event fires after renderEntities() changes the bound texture and
+            // after disableLightmap() turns off texture unit 1. We must restore both
+            // before drawing so the preview uses the correct atlas and brightness.
+            Minecraft mc = Minecraft.getMinecraft();
+            mc.getTextureManager().bindTexture(TextureMap.locationBlocksTexture);
+            mc.entityRenderer.enableLightmap((double) e.partialTicks);
+
             GL11.glPushMatrix();
             GL11.glTranslated(-tX, -tY, -tZ);
             GL11.glDepthMask(false);
             GL11.glEnable(GL11.GL_CULL_FACE);
+            GL11.glCullFace(GL11.GL_BACK);
             GL11.glEnable(GL11.GL_BLEND);
             OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ONE, GL11.GL_ZERO);
             tess.startDrawingQuads();
@@ -98,6 +108,8 @@ public class PreviewRenderer {
             GL11.glDepthMask(true);
             GL11.glDisable(GL11.GL_BLEND);
             GL11.glPopMatrix();
+
+            mc.entityRenderer.disableLightmap((double) e.partialTicks);
             shapeTile.setWorldObj(null);
         }
     }

--- a/src/main/java/gcewing/architecture/client/render/target/RenderTargetWorld.java
+++ b/src/main/java/gcewing/architecture/client/render/target/RenderTargetWorld.java
@@ -186,6 +186,12 @@ public class RenderTargetWorld extends RenderTargetBase {
         va = a();
         vlm1 = br >> 16;
         vlm2 = br & 0xffff;
+        // Additive blending makes a zero-brightness preview invisible. Enforce a
+        // floor so the shape is always discernible even in unlit areas.
+        if (inPreview) {
+            vlm1 = Math.max(vlm1, 80);
+            vlm2 = Math.max(vlm2, 80);
+        }
     }
 
     public boolean end() {


### PR DESCRIPTION
DrawBlockHighlightEvent fires after renderEntities() changes the bound texture (entity skins, never restored) and after disableLightmap() kills texture unit 1. PreviewRenderer was drawing with whatever texture happened to be last bound and no lightmap, so the result varied by camera angle (which entities were in view) and by chunk lighting (dark areas made vertex color near zero, invisible with additive blend). Fixed by binding the block atlas and enabling the lightmap before the draw call, then restoring lightmap state after. Added glCullFace(GL_BACK) so a mod that changed the cull mode can't break the preview. Also added a minimum lightmap floor of 80 in RenderTargetWorld for inPreview so the shape stays visible in completely unlit spaces.