### PR TITLE
Transform Architecture Blocks with Postea API

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,7 +3,8 @@
 dependencies {
     api("com.github.GTNewHorizons:GTNHLib:0.9.0:dev")
     compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta68a:dev')
-
+    compileOnly("com.github.GTNewHorizons:Postea:1.2.5:dev") {transitive = false}
+    
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.8.48-GTNH:dev')
     devOnlyNonPublishable('com.github.GTNewHorizons:waila:1.9.15:dev')
 }

--- a/src/main/java/gcewing/architecture/ArchitectureCraft.java
+++ b/src/main/java/gcewing/architecture/ArchitectureCraft.java
@@ -16,6 +16,8 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.WorldServer;
 
+import com.gtnewhorizons.postea.api.ItemStackReplacementManager;
+
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
@@ -28,6 +30,7 @@ import gcewing.architecture.client.render.model.IArchitectureModel;
 import gcewing.architecture.client.render.model.ObjJsonModel;
 import gcewing.architecture.common.config.ArchitectConfiguration;
 import gcewing.architecture.common.network.DataChannel;
+import gcewing.architecture.compat.ItemShapeTransformer;
 
 @Mod(
         modid = ArchitectureCraft.MOD_ID,
@@ -86,6 +89,9 @@ public class ArchitectureCraft {
         saveConfig();
         NetworkRegistry.INSTANCE.registerGuiHandler(this, new ArchitectureGuiHandler());
         posteaLoaded = Loader.isModLoaded("postea");
+        if (posteaLoaded) {
+            ItemStackReplacementManager.addTransformationHandler("ArchitectureCraft:shape", new ItemShapeTransformer());
+        }
     }
 
     public ArchitectureCraftClient initClient() {

--- a/src/main/java/gcewing/architecture/ArchitectureCraft.java
+++ b/src/main/java/gcewing/architecture/ArchitectureCraft.java
@@ -17,6 +17,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.WorldServer;
 
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLInterModComms;
@@ -51,6 +52,8 @@ public class ArchitectureCraft {
 
     public static DataChannel channel;
 
+    public static boolean posteaLoaded = false;
+
     public ArchitectureCraft() {
         super();
         channel = new DataChannel(MOD_ID);
@@ -82,6 +85,7 @@ public class ArchitectureCraft {
         if (client != null) client.postInit(e);
         saveConfig();
         NetworkRegistry.INSTANCE.registerGuiHandler(this, new ArchitectureGuiHandler());
+        posteaLoaded = Loader.isModLoaded("postea");
     }
 
     public ArchitectureCraftClient initClient() {

--- a/src/main/java/gcewing/architecture/ArchitectureCraft.java
+++ b/src/main/java/gcewing/architecture/ArchitectureCraft.java
@@ -16,8 +16,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.WorldServer;
 
-import com.gtnewhorizons.postea.api.ItemStackReplacementManager;
-
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
@@ -30,7 +28,7 @@ import gcewing.architecture.client.render.model.IArchitectureModel;
 import gcewing.architecture.client.render.model.ObjJsonModel;
 import gcewing.architecture.common.config.ArchitectConfiguration;
 import gcewing.architecture.common.network.DataChannel;
-import gcewing.architecture.compat.ItemShapeTransformer;
+import gcewing.architecture.compat.PosteaCompat;
 
 @Mod(
         modid = ArchitectureCraft.MOD_ID,
@@ -90,7 +88,7 @@ public class ArchitectureCraft {
         NetworkRegistry.INSTANCE.registerGuiHandler(this, new ArchitectureGuiHandler());
         posteaLoaded = Loader.isModLoaded("postea");
         if (posteaLoaded) {
-            ItemStackReplacementManager.addTransformationHandler("ArchitectureCraft:shape", new ItemShapeTransformer());
+            PosteaCompat.registerTransformers();
         }
     }
 

--- a/src/main/java/gcewing/architecture/common/tile/TileShape.java
+++ b/src/main/java/gcewing/architecture/common/tile/TileShape.java
@@ -6,6 +6,7 @@
 
 package gcewing.architecture.common.tile;
 
+import static gcewing.architecture.ArchitectureCraft.posteaLoaded;
 import static gcewing.architecture.compat.BlockCompatUtils.blockCanRenderInLayer;
 import static gcewing.architecture.compat.BlockCompatUtils.getBlockStateFromMeta;
 import static gcewing.architecture.compat.BlockCompatUtils.getDefaultBlockState;
@@ -24,6 +25,10 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.IBlockAccess;
+
+import com.gtnewhorizons.postea.utility.BlockConversionInfo;
+import com.gtnewhorizons.postea.utility.IDRegistry;
+import com.gtnewhorizons.postea.utility.TransformerRegistry;
 
 import gcewing.architecture.common.item.ItemCladding;
 import gcewing.architecture.common.shape.Shape;
@@ -124,15 +129,29 @@ public class TileShape extends TileArchitecture {
 
     protected IBlockState nbtGetBlockState(NBTTagCompound nbt, String nameField, String dataField) {
         String blockName = nbt.getString(nameField);
-        if (blockName != null && blockName.length() > 0) {
-            Block block = Block.getBlockFromName(blockName);
+        if (blockName != null && !blockName.isEmpty()) {
             int data = nbt.getInteger(dataField);
+            Block block = null;
+
+            // Hook Postea registry to transform blocks
+            if (posteaLoaded) {
+                BlockConversionInfo converted = TransformerRegistry
+                        .getBlockReplacement(IDRegistry.getBlockId(blockName), (byte) data, null, 0, 0, 0);
+
+                if (converted != null) {
+                    block = Block.getBlockById(converted.blockID);
+                    data = converted.metadata;
+                }
+            }
+            // Normal path
+            if (block == null) block = Block.getBlockFromName(blockName);
+
+            // Missing + no transform
             if (block == null) {
                 block = Blocks.planks;
                 data = 0;
             }
-            IBlockState state = getBlockStateFromMeta(block, data);
-            return state;
+            return getBlockStateFromMeta(block, data);
         }
         return null;
     }

--- a/src/main/java/gcewing/architecture/compat/ItemShapeTransformer.java
+++ b/src/main/java/gcewing/architecture/compat/ItemShapeTransformer.java
@@ -1,0 +1,36 @@
+package gcewing.architecture.compat;
+
+import static gcewing.architecture.compat.BlockCompatUtils.getNameForBlock;
+
+import net.minecraft.block.Block;
+import net.minecraft.nbt.NBTTagCompound;
+
+import com.gtnewhorizons.postea.api.IItemStackTransformationHandler;
+import com.gtnewhorizons.postea.utility.BlockConversionInfo;
+import com.gtnewhorizons.postea.utility.IDRegistry;
+import com.gtnewhorizons.postea.utility.TransformerRegistry;
+
+public class ItemShapeTransformer implements IItemStackTransformationHandler {
+
+    @Override
+    public boolean apply(String originalId, NBTTagCompound stack) {
+        if (stack.hasKey("tag")) {
+            NBTTagCompound tag = stack.getCompoundTag("tag");
+
+            String blockName = tag.getString("BaseName");
+            if (blockName == null) return false;
+
+            int data = tag.getInteger("BaseData");
+            BlockConversionInfo converted = TransformerRegistry
+                    .getBlockReplacement(IDRegistry.getBlockId(blockName), (byte) data, null, 0, 0, 0);
+
+            if (converted != null) {
+                tag.setInteger("BaseData", converted.metadata);
+                tag.setString("BaseName", getNameForBlock(Block.getBlockById(converted.blockID)));
+                stack.setTag("tag", tag);
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/gcewing/architecture/compat/PosteaCompat.java
+++ b/src/main/java/gcewing/architecture/compat/PosteaCompat.java
@@ -1,0 +1,10 @@
+package gcewing.architecture.compat;
+
+import com.gtnewhorizons.postea.api.ItemStackReplacementManager;
+
+public class PosteaCompat {
+
+    public static void registerTransformers() {
+        ItemStackReplacementManager.addTransformationHandler("ArchitectureCraft:shape", new ItemShapeTransformer());
+    }
+}


### PR DESCRIPTION
Converts ArchitectureCraft TEs using Postea's TransformerRegistry. Tested with Extra Utilities -> Utilities in Excess transformers:
<img width="632" height="420" alt="image" src="https://github.com/user-attachments/assets/a7a9c5e6-7110-4965-9ccd-217c896293e4" />

Also registers a stack transformer that fixes the NBT of all shape blocks using the Postea registry on load.

Closes https://github.com/GTNewHorizons/UtilitiesInExcess/issues/223